### PR TITLE
Potential fix for code scanning alert no. 45: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rameshsunkara/go-rest-api-example/security/code-scanning/45](https://github.com/rameshsunkara/go-rest-api-example/security/code-scanning/45)

To fix the issue, add a top-level `permissions` block to the workflow in `.github/workflows/cibuild.yml`, specifying the minimum required permissions for all jobs. In this case, the jobs only require read access to the repository contents (`contents: read`) to perform code checkout operations, and do not appear to need any write access. This block should be placed at the top level of the YAML file, before the `jobs:` section, so it applies to all jobs unless overridden within a specific job. No other code changes, imports, or updates are needed in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
