### PR TITLE
fix the API example in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Your API is now running at `http://localhost:8080`
 
 **Try it out:**
 ```bash
-curl http://localhost:8080/api/v1/healthz
-curl http://localhost:8080/api/v1/orders
+curl http://localhost:8080/healthz
+curl http://localhost:8080/ecommerce/v1/orders
 ```
 
 ## 📟 Available Commands


### PR DESCRIPTION
Updating the readme file with the correct endpoint, I think the api endpoint does not exist